### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
 setting.py
+# Created by https://www.gitignore.io/api/opencv
+
+### OpenCV ###
+#OpenCV for Mac and Linux
+#build and release folders
+*/CMakeFiles
+*/CMakeCache.txt
+*/Makefile
+*/cmake_install.cmake
+.DS_Store
+
+
+# End of https://www.gitignore.io/api/opencv


### PR DESCRIPTION
¿Que ha cambiado?
Agregamos al gitignore soporte para Opencv
- [ ] Frontend
- [ ] Backend
- [x] Configuración del server

# Como puedo probar los cambios?
por ejemplo los rachivos y la carpeta opencv ya no se suben al repo. ver el archivo gitignore